### PR TITLE
Genreate SBOM with new action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,18 +34,17 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Install bom
-        uses: kubernetes-sigs/release-actions/setup-bom@c130b4494862d330a1aa4de320076c666d0708da # v0.4.4
-
-      - name: Generate SBOM
-        shell: bash
-        run: |
-          bom generate --format=json -o /tmp/${{github.event.repository.name}}-${{ steps.tag.outputs.tag_name }}.spdx.json .
-
       - name: Publish Release
         uses: kubernetes-sigs/release-actions/publish-release@c130b4494862d330a1aa4de320076c666d0708da # v0.4.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          assets: "/tmp/${{github.event.repository.name}}-${{ steps.tag.outputs.tag_name }}.spdx.json"
           sbom: false
+
+      - name: Generate SBOM
+        id: sbom
+        uses: carabiner-dev/actions/unpack/sbom@2a4b2cd115ede14629b03ef7e77586d3269d4c72 # v1.2.3
+        with:
+          push-to-release: ${{ steps.tag.outputs.tag_name }}
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request updates the Software Bill of Materials (SBOM) generation process in the release workflow. The main change is switching from the `setup-bom` and manual `bom generate` approach to using the `carabiner-dev/actions/unpack/sbom` GitHub Action. This simplifies and streamlines SBOM generation and publishing.

**SBOM generation and publishing changes:**

* Removed installation and usage of `kubernetes-sigs/release-actions/setup-bom` and manual `bom generate` command. (`.github/workflows/release.yaml`)
* Added `carabiner-dev/actions/unpack/sbom` action for automated SBOM generation and publishing, configured to push the SBOM to the release using the current tag. (`.github/workflows/release.yaml`)
* Updated the release publishing step to no longer specify SBOM assets directly and set `sbom: false`, as SBOM handling is now managed by the new action. (`.github/workflows/release.yaml`)