### PR TITLE
Update golangci-lint to v2.13

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
-          version: v2.11
+          version: v2.13

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -60,7 +60,7 @@ linters:
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan

--- a/client_test.go
+++ b/client_test.go
@@ -38,7 +38,7 @@ func TestCall(t *testing.T) {
 		synthErr error
 	}{
 		{"normal", []byte("Hi\n"), nil},
-		{"normal", nil, errors.New("Superbad HTTP Error!")},
+		{"http-error", nil, errors.New("Superbad HTTP Error!")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/functions_test.go
+++ b/functions_test.go
@@ -11,16 +11,17 @@ import (
 
 func TestRepoFromString(t *testing.T) {
 	t.Parallel()
+	const cosignRepoURL = "https://github.com/sigstore/cosign"
 	for _, tc := range []struct {
 		name    string
 		sut     string
 		expect  string
 		mustErr bool
 	}{
-		{"reposlug", "sigstore/cosign", "https://github.com/sigstore/cosign", false},
-		{"noscheme", "github.com/sigstore/cosign", "https://github.com/sigstore/cosign", false},
+		{"reposlug", "sigstore/cosign", cosignRepoURL, false},
+		{"noscheme", "github.com/sigstore/cosign", cosignRepoURL, false},
 		{"norepo", "github.com/sigstore", "", true},
-		{"locator", "git+https://github.com/sigstore/cosign@main", "https://github.com/sigstore/cosign", false},
+		{"locator", "git+https://github.com/sigstore/cosign@main", cosignRepoURL, false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()


### PR DESCRIPTION
Bumps the golangci-lint version pinned in the repository's lint workflow(s) from v2.11 to v2.13.

Latest release: https://github.com/golangci/golangci-lint/releases/tag/v2.13.1

Signed-off-by: Biner <biner@carabiner.dev>
